### PR TITLE
change useeffect to not be async

### DIFF
--- a/src/ShapeFile.js
+++ b/src/ShapeFile.js
@@ -6,8 +6,11 @@ const ShapeFile = (props) => {
   const [ geoJSONData, setGeoJSONData ] = useState(null)
   const { data, ...geoJSONProps} = props
 
-  useEffect(async () => {
-    setGeoJSONData(await shp(props.data))
+  useEffect(() => {
+    const parseData = async () => {
+      setGeoJSONData(await shp(props.data))
+    }
+    parseData();
   }, [props.data])
 
  return (


### PR DESCRIPTION
Using async functions in useEffect is not supported anymore.

The function in useEffect should return nothing or a function (cleanup). This change fixes the problem (destroy is not a function)